### PR TITLE
Styles: Absolute position center pad

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -13,6 +13,7 @@
 .groups {
   width: 43em;
   height: 43em;
+  position: relative;
 }
 
 .pad {
@@ -24,12 +25,12 @@
   background-color: #333;
   border: 10px solid #333;
   border-radius: 100%;
-  position: relative;
+  position: absolute;
   text-align: center;
   height: 20em;
   width: 20em;
-  left: 11em;
-  top: 11em;
+  top: 10.5em;
+  left: 10.5em;
 }
 
 .center-pad h2 {
@@ -56,7 +57,7 @@
 
 .configs {
   position: relative;
-  top: -34em;
+  top: 7em;
 }
 
 .config {


### PR DESCRIPTION
**Bug**
The _div.configs_ element left an extra space of ~34em underneath it, I don't get exactly why this happens but it is a combination of relative positioning and the negative top.

This guy here might have had a similar issue:
[CSS using negative relative positioning issue](https://stackoverflow.com/questions/2280625/css-using-negative-relative-positioning-issue)

**Solution**
Absolute position the _div.configs_ and use positive indexes instead.

Closes #1 